### PR TITLE
Autolean if weapon is in ironsights + disallow leans in certain player states

### DIFF
--- a/leaning/lua/autorun/!!!!tfa_lean.lua
+++ b/leaning/lua/autorun/!!!!tfa_lean.lua
@@ -87,16 +87,27 @@ hook.Add("PlayerButtonUp", "leaning_keys", function(ply, button)
     end
 end)
 
+local function can_lean(ply)
+    if !ply:OnGround() then return false end -- no leans in air
+    if ply:IsSprinting() and ply:KeyDown(IN_FORWARD + IN_BACK + IN_MOVELEFT + IN_MOVERIGHT) then return false end -- no leans while sprint, checking if ply is actually moving
+    if ply.GetSliding and ply:GetSliding() then return false end -- sliding mods support
+    local wep = ply:GetActiveWeapon()
+    if wep and !wep.CanLean then return false end -- arc9 has this on some guns, some other mods could add this too
+    return true
+end
+
 hook.Add("SetupMove", "leaning_main", function(ply, mv, cmd)
     local eyepos = ply:EyePos() - ply:GetNW2Vector("leaning_best_head_offset")
     local angles = cmd:GetViewAngles()
 
+    local canlean = can_lean(ply)
+
     local fraction = ply:GetNW2Float("leaning_fraction", 0)
 
-    local leaning_left = ply:GetNW2Bool("leaning_left")
-    local leaning_right = ply:GetNW2Bool("leaning_right")
-    local leaning_ron = ply:GetNW2Bool("leaning_ron")
     local leaning_auto = ply:GetNW2Bool("leaning_auto")
+    local leaning_left = ply:GetNW2Bool("leaning_left") and canlean
+    local leaning_right = ply:GetNW2Bool("leaning_right") and canlean
+    local leaning_ron = ply:GetNW2Bool("leaning_ron") and canlean
 
     if debugmode:GetBool() then
         debugoverlay.ScreenText(0.2, 0.2, "leaning_left: "..bool_to_str(leaning_left).." | leaning_right: "..bool_to_str(leaning_right).." | leaning_ron: "..bool_to_str(leaning_ron).." | leaning_auto: "..bool_to_str(leaning_auto), FrameTime() * 5, color_white)

--- a/leaning/lua/autorun/!!!!tfa_lean.lua
+++ b/leaning/lua/autorun/!!!!tfa_lean.lua
@@ -8,6 +8,7 @@ local interp = CreateConVar("cl_lean_interp_ratio", 2, flags, nil, 1)
 local unpredicted = CreateConVar("sv_lean_unpredicted", 0, flags, "Restores some compatibility with mods that also alter the view offset.")
 local debugmode = CreateConVar("sv_lean_debug", 0, flags, "a buncha shit")
 local notify = CreateConVar("sv_lean_notify", 0, flags, "a buncha shit")
+local allow_crouch_leans = CreateConVar("sv_lean_allowcrouch", 1, flags)
 
 local hull_size_4 = Vector(4, 4, 4)
 local hull_size_5 = Vector(5, 5, 5)
@@ -91,6 +92,7 @@ local function can_lean(ply)
     if !ply:OnGround() then return false end -- no leans in air
     if ply:IsSprinting() and ply:KeyDown(IN_FORWARD + IN_BACK + IN_MOVELEFT + IN_MOVERIGHT) then return false end -- no leans while sprint, checking if ply is actually moving
     if ply.GetSliding and ply:GetSliding() then return false end -- sliding mods support
+    if !allow_crouch_leans:GetBool() and ply:Crouching() then return false end
     local wep = ply:GetActiveWeapon()
     if wep and !wep.CanLean then return false end -- arc9 has this on some guns, some other mods could add this too
     return true

--- a/leaning/lua/autorun/!!!!tfa_lean.lua
+++ b/leaning/lua/autorun/!!!!tfa_lean.lua
@@ -488,6 +488,12 @@ if CLIENT then
         sights:SetText("Toggle autolean when aiming weapon.")
 
         for i, data in ipairs(binds) do
+            local l = vgui.Create("DLabel", scroll)
+            l:Dock(TOP)
+            l:DockMargin(m, m / 8, m, m)
+            l:SetColor(color_white)
+            l:SetText(data[2])
+            
             local binder = vgui.Create("DBinder", scroll)
 
             local convar_name = data[1]
@@ -516,12 +522,6 @@ if CLIENT then
                     LocalPlayer():ChatPrint("New bound key: "..input.GetKeyName(num).." "..convar_name)
                 end
             end
-
-            local l = vgui.Create("DLabel", scroll)
-            l:Dock(TOP)
-            l:DockMargin(m, m / 8, m, m * 5)
-            l:SetColor(color_white)
-            l:SetText(data[2])
         end
     end)
 end


### PR DESCRIPTION
New feature with convar to force auto lean if current player weapon is being in sights (works with arccw, arc9, tfa, mwbase, fas2 and technically anything with mouse2 bind)

Disallow leans while sprinting, being in air, sliding (with custom mods), crouching (only with special convar, allowed by default), having swep with CanLean = false value in hands (some arc9 guns, but any other swep can use this too)

also slightly better binding menu layout

Doing this because i've stripped leans from arc9 weapon base and some people aren't happy there's no mods with ez autoleaning in ironsights. Tested in mp and sp, works fine